### PR TITLE
Clean up LABTASKS questions

### DIFF
--- a/LABTASKS.md
+++ b/LABTASKS.md
@@ -7,6 +7,16 @@ Responses to questions should be submitted as specified by your instructor.
 
 If you're ever confused about what you need to do for a given task, ask.
 
+## Exploring the project
+
+Look over the directory structure of the project before you start
+making changes to it, and consider the various tools that we are
+using to manage our project.
+
+:question: What is the purpose of `.gitignore`?
+:question: What is 'Gradle'? What is the purpose of `build.gradle`?
+:question: What is the purpose of 'Travis'?
+
 ## Exploring the server
 
 Study the server (Java) code in project you have cloned.
@@ -57,10 +67,6 @@ is it displayed?
 
 :question: Where is the client-side JavaScript defined? Name the file(s) in which it is used.
 
-:question: What is the purpose of build.gradle file? What's in it, and what does it mean?
-
-:question: What's in .gitgnore file? What's the purpose of it?
-
 ## Extending the server API
 
 The initial server (Java) code demonstrates reading in a
@@ -68,7 +74,7 @@ collection of (randomly generated) user data, and making it
 available (with filtering) via the simple API you explored above.
 
 Your task here is to use test-driven development (TDD) to
-extend the server's API to support serving to-do data. There
+extend the server's API to support serving 'to-do' data. There
 is a file `data/todos` that has several hundred randomly
 generated "to-do"s, each of which has:
 * A unique `_id`
@@ -109,19 +115,3 @@ api/todos?owner=Blanche&status=complete&limit=12
 
 which would return the first 12 completed to-dos owned by
 Blanche.
-
-##### Find the client-side testing file, describe where it is located and what it is testing. Run karma (the client-side testing engine) as specified in the README and describe results. Do not edit any files at this time.
-
-##### Find the server-side testing file, describe where it is located and what it is testing. Run JUnit as specified in the README and describe results. Do not edit any files at this time.
-
-##### After having set up Travis CI with your forked project, play around with the page for your project (build history, settings, branches, etc) and describe at least 3 features you think would be useful when troubleshooting a broken project or failing build.
-
-##### What was the build status of your project right after you got everything set up? Use Travis to find any problems, and describe what failed, if anything. (Which files, what lines, why did failure occur, etc.)
-
-##### Fix any problems described in the previous question. Describe how you fixed them. Push your fix to GitHub and post a link to the passing build (from the build history) here.
-
-- Study jasmine testing syntax. Think of a JavaScript function, describe its behavior by writing tests for it (this is test-driven development, or TDD). Add the function, run the tests. (Actually do this. Don't forget to commit and push your changes!)
-
-## Part #3: Adding something other than a GPA calculator!
-
-> TODO: Write vague instructions for this!


### PR DESCRIPTION
There are 13 questions for groups to answer before they begin to implement the to-do API.
All 13 questions are relatively straightforward, being mostly questions about the basic structure
of the project or the tools involved.

It's important that students become familiar with the structure of the project and the roles that
all of the tools play in development, so I don't feel too bad about 13 short questions that
require them to dig around in the project a bit. 

I removed all of the questions and procedure regarding TravisCI - perhaps we should make relegate Travis
to the README / project setup in the future and avoid having people answer questions about it beyond
asking them to explain what it is this time (the first time they've seen it).
```
- Removed old questions
- Removed references to GPA calculator
- Added 'Exploring the project' section
- Moved gradle question and gitignore question to that section
- Misc. other small changes.

Issue: #3 
```