### PR TITLE
Remove spark debug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ repositories {
 // External dependencies that our application utilizes
 dependencies {
   compile 'com.sparkjava:spark-core:2.6.0'
-  compile 'com.sparkjava:spark-debug-tools:0.5'
   compile 'org.slf4j:slf4j-simple:1.7.26'
   compile 'com.google.code.gson:gson:2.8.5'
 

--- a/src/main/java/umm3601/Server.java
+++ b/src/main/java/umm3601/Server.java
@@ -9,7 +9,6 @@ import umm3601.user.UserController;
 import java.io.IOException;
 
 import static spark.Spark.*;
-import static spark.debug.DebugScreen.*;
 
 public class Server {
 
@@ -25,7 +24,6 @@ public class Server {
     port(4567);
     // Specify where assets like images will be "stored"
     staticFiles.location("/public");
-    enableDebugScreen();
 
     // Simple example route
     get("/hello", (req, res) -> "Hello World");


### PR DESCRIPTION
This removes the dependencies and usage of the Spark debug tools. They are apparently the reason we can't upgrade Spark past v2.7. It's a slight bummer to lose the debugging tools, but to be honest we (& the students) never used them all that much, so it's probably not a huge deal.

This PR does _not_ upgrade Spark itself; I'm leaving that to the relevant Dependabot pull requests. We should do this before we do any PRs that upgrade Spark, though.