### PR TITLE
Isolate http request logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty 
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
 - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/src/main/resources/public/javascript/users.js
+++ b/src/main/resources/public/javascript/users.js
@@ -4,8 +4,7 @@
 function getAllUsers() {
   console.log("Getting all the users.");
 
-  var HttpThingy = new HttpClient();
-  HttpThingy.get("/api/users", function (returned_json) {
+  get("/api/users", function (returned_json) {
     document.getElementById('jsonDump').innerHTML = returned_json;
   });
 }
@@ -13,41 +12,7 @@ function getAllUsers() {
 function getAllUsersByAge() {
   console.log("Getting all the users.");
 
-  var HttpThingy = new HttpClient();
-  HttpThingy.get("/api/users?age=" + document.getElementById("age").value, function (returned_json) {
+  get("/api/users?age=" + document.getElementById("age").value, function (returned_json) {
     document.getElementById('jsonDump').innerHTML = returned_json;
   });
-}
-
-/**
- * Wrapper to make generating http requests easier. Should maybe be moved
- * somewhere else in the future!.
- *
- * Based on: http://stackoverflow.com/a/22076667
- * Now with more comments!
- */
-function HttpClient() {
-  // We'll take a URL string, and a callback function.
-  this.get = function (aUrl, aCallback) {
-    var anHttpRequest = new XMLHttpRequest();
-
-    // Set a callback to be called when the ready state of our request changes.
-    anHttpRequest.onreadystatechange = function () {
-
-      /**
-       * Only call our 'aCallback' function if the ready state is 'DONE' and
-       * the request status is 200 ('OK')
-       *
-       * See https://httpstatuses.com/ for HTTP status codes
-       * See https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState
-       *  for XMLHttpRequest ready state documentation.
-       *
-       */
-      if (anHttpRequest.readyState === 4 && anHttpRequest.status === 200)
-        aCallback(anHttpRequest.responseText);
-    };
-
-    anHttpRequest.open("GET", aUrl, true);
-    anHttpRequest.send(null);
-  }
 }

--- a/src/main/resources/public/javascript/util.js
+++ b/src/main/resources/public/javascript/util.js
@@ -1,0 +1,29 @@
+/**
+ * Utility function to make generating http requests easier.
+ * Sends a GET request to the URL described by 'aUrl' with
+ * our 'aCallback' function to be executed when the server
+ * sends a response.
+ *
+ * Based on: http://stackoverflow.com/a/22076667
+ */
+export function get(aUrl, aCallback) {
+  var anHttpRequest = new XMLHttpRequest();
+
+  // Set a callback to be called when the ready state of our request changes.
+  anHttpRequest.onreadystatechange = function () {
+    /**
+     * Only call our 'aCallback' function if the ready state is 'DONE' and
+     * the request status is 200 ('OK')
+     *
+     * See https://httpstatuses.com/ for HTTP status codes
+     * See https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState
+     *  for XMLHttpRequest ready state documentation.
+     *
+     */
+    if (anHttpRequest.readyState === 4 && anHttpRequest.status === 200)
+      aCallback(anHttpRequest.responseText);
+  };
+
+  anHttpRequest.open("GET", aUrl, true);
+  anHttpRequest.send(null);
+}

--- a/src/main/resources/public/javascript/util.js
+++ b/src/main/resources/public/javascript/util.js
@@ -6,7 +6,7 @@
  *
  * Based on: http://stackoverflow.com/a/22076667
  */
-export function get(aUrl, aCallback) {
+function get(aUrl, aCallback) {
   var anHttpRequest = new XMLHttpRequest();
 
   // Set a callback to be called when the ready state of our request changes.

--- a/src/main/resources/public/users.html
+++ b/src/main/resources/public/users.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Users</title>
   <link rel="stylesheet" type="text/css" href="css/users.css">
+  <script type="text/javascript" src="javascript/util.js"></script>
   <script type="text/javascript" src="javascript/users.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Separated the `HttpClient()` function into a `util.js` file, named the function `get`, and added script tag to load `util.js` globally on the `users.html` page.