### PR TITLE
Add dependabot config file with server directory specified

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+# Dependabot config file
+# https://dependabot.com/docs/config-file/
+version: 1
+update_configs:
+  # Keep server/build.gradle up to date, batching pull requests weekly
+  - package_manager: "java:gradle"
+    directory: "/server"
+    update_schedule: "weekly"


### PR DESCRIPTION
This should fix #87, Dependabot not being able to find our `build.gradle`.