### PR TITLE
Handle illegal ages

### DIFF
--- a/client/javascript/todos.js
+++ b/client/javascript/todos.js
@@ -24,6 +24,6 @@ function getFilteredTodos() {
   }
 
   get(url, function(returned_json){
-    document.getElementById('jsonDump').innerHTML = syntaxHighlight(JSON.stringify(JSON.parse(returned_json), null, 2));
+    document.getElementById('jsonDump').innerHTML = syntaxHighlight(JSON.stringify(returned_json, null, 2));
   });
 }

--- a/client/javascript/users.js
+++ b/client/javascript/users.js
@@ -34,6 +34,6 @@ function getFilteredUsers() {
 
 
   get(url, function(returned_json){
-    document.getElementById('jsonDump').innerHTML = syntaxHighlight(JSON.stringify(JSON.parse(returned_json), null, 2));
+    document.getElementById('jsonDump').innerHTML = syntaxHighlight(JSON.stringify(returned_json, null, 2));
   });
 }

--- a/client/javascript/util.js
+++ b/client/javascript/util.js
@@ -1,31 +1,40 @@
+/*
+ * The next two functions `status` and `json` are used by
+ * `get` below to check the status of an HTTP response
+ * and convert the response to JSON.
+ */
+function status(response) {
+  if (response.status >= 200 && response.status < 300) {
+    return Promise.resolve(response)
+  } else {
+    return Promise.reject(new Error(response.statusText))
+  }
+}
+
+function json(response) {
+  return response.json()
+}
+
 /**
  * Utility function to make generating http requests easier.
  * Sends a GET request to the URL described by 'aUrl' with
  * our 'aCallback' function to be executed when the server
  * sends a response.
  *
- * Based on: http://stackoverflow.com/a/22076667
+ * Uses functions `status` and `json` to process the status
+ * and parse the results to JSON.
+ *
+ * Based on: https://stackoverflow.com/a/38297729 and
+ * https://developers.google.com/web/updates/2015/03/introduction-to-fetch?hl=en#chaining_promises
  */
 function get(aUrl, aCallback) {
-  var anHttpRequest = new XMLHttpRequest();
-
-  // Set a callback to be called when the ready state of our request changes.
-  anHttpRequest.onreadystatechange = function () {
-    /**
-     * Only call our 'aCallback' function if the ready state is 'DONE' and
-     * the request status is 200 ('OK')
-     *
-     * See https://httpstatuses.com/ for HTTP status codes
-     * See https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState
-     *  for XMLHttpRequest ready state documentation.
-     *
-     */
-    if (anHttpRequest.readyState === 4 && anHttpRequest.status === 200)
-      aCallback(anHttpRequest.responseText);
-  };
-
-  anHttpRequest.open("GET", aUrl, true);
-  anHttpRequest.send(null);
+  fetch(aUrl)
+    .then(status)
+    .then(json)
+    .then(aCallback)
+    .catch(function(error) {
+      window.alert("There was a problem accessing this URL: " + aUrl + "\nError: <" + error + ">");
+    });
 }
 
 // Syntax highlighting for JSON

--- a/server/bin/test/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/server/bin/test/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/server/src/main/java/umm3601/user/Database.java
+++ b/server/src/main/java/umm3601/user/Database.java
@@ -8,6 +8,8 @@ import java.util.Map;
 
 import com.google.gson.Gson;
 
+import io.javalin.http.BadRequestResponse;
+
 /**
  * A fake "database" of user info
  * <p>
@@ -52,8 +54,13 @@ public class Database {
 
     // Filter age if defined
     if (queryParams.containsKey("age")) {
-      int targetAge = Integer.parseInt(queryParams.get("age").get(0));
-      filteredUsers = filterUsersByAge(filteredUsers, targetAge);
+      String ageParam = queryParams.get("age").get(0);
+      try {
+        int targetAge = Integer.parseInt(ageParam);
+        filteredUsers = filterUsersByAge(filteredUsers, targetAge);
+      } catch (NumberFormatException e) {
+        throw new BadRequestResponse("Specified age '" + ageParam + "' can't be parsed to an integer");
+      }
     }
     // Filter company if defined
     if (queryParams.containsKey("company")) {

--- a/server/src/test/java/umm3601/user/UserControllerSpec.java
+++ b/server/src/test/java/umm3601/user/UserControllerSpec.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import io.javalin.core.validation.Validator;
+import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 import io.javalin.http.NotFoundResponse;
 
@@ -55,7 +56,6 @@ public class UserControllerSpec {
 
   @Test
   public void GET_to_request_age_25_users() throws IOException {
-
     Map<String, List<String>> queryParams = new HashMap<>();
     queryParams.put("age", Arrays.asList(new String[] { "25" }));
 
@@ -68,6 +68,26 @@ public class UserControllerSpec {
     for (User user : argument.getValue()) {
       assertEquals(25, user.age);
     }
+  }
+
+  /**
+   * Test that if the user sends a request with an illegal value in
+   * the age field (i.e., something that can't be parsed to a number)
+   * we get a reasonable error code back.
+   */
+  @Test
+  public void GET_to_request_users_with_illegal_age() {
+    // We'll set the requested "age" to be a string ("abc")
+    // that can't be parsed to a number.
+    Map<String, List<String>> queryParams = new HashMap<>();
+    queryParams.put("age", Arrays.asList(new String[] { "abc" }));
+
+    when(ctx.queryParamMap()).thenReturn(queryParams);
+    // This should now throw a `BadRequestResponse` exception because
+    // our request has an age that can't be parsed to a number.
+    Assertions.assertThrows(BadRequestResponse.class, () -> {
+      userController.getUsers(ctx);
+    });
   }
 
   @Test


### PR DESCRIPTION
This adds code on the server side that checks for age parameters that can't be parsed as integers, and returns a bad request response (status 400) in that case.

It also extends the client code to check for error statuses and display a simple alert if something like that happens.

Two potential concerns:

- I think we should be using Javalin `Validators` on the server side instead of a basic `try-catch`, but I'm a little unthrilled about the way in watch that will end up making the `Database` class dependent on Javalin, where it used to be framework agnostic. (Note that I've already let a little of Javalin bleed into the DB by using the `BadRequestResponse` class.)
- The error handling on the client side is pretty crude. We might want to spiff that up as a better model?