### PR TITLE
Fix relative path to the badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSCI 3601 Lab #2 - Building a web server in Java with Javalin
 
-[![Server Build Status](workflows/Server%20Java/badge.svg)](actions)
+[![Server Build Status](../../workflows/Server%20Java/badge.svg)](actions)
 
 Here you will explore serving up a simple website that you create,
 using a server written with the [Javalin framework][javalin-io] server.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSCI 3601 Lab #2 - Building a web server in Java with Javalin
 
-[![Server Build Status](../../workflows/Server%20Java/badge.svg?branch=master)](actions)
+[![Server Build Status](../../workflows/Server%20Java/badge.svg?branch=master)](../../actions?query=workflow%3A"Server+Java")
 
 Here you will explore serving up a simple website that you create,
 using a server written with the [Javalin framework][javalin-io] server.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSCI 3601 Lab #2 - Building a web server in Java with Javalin
 
-[![Server Build Status](../../workflows/Server%20Java/badge.svg)](actions)
+[![Server Build Status](../../workflows/Server%20Java/badge.svg?branch=master)](actions)
 
 Here you will explore serving up a simple website that you create,
 using a server written with the [Javalin framework][javalin-io] server.


### PR DESCRIPTION
Previously, the relative path in README.md was
    workflows/Server%20Java/badge.svg

Since the full path of README.md is
    https://github.com/UMM-CSci-3601/3601-lab2_client-server/raw/master/README.md
the old relative path referred to
    https://github.com/UMM-CSci-3601/3601-lab2_client-server/raw/master/workflows/Server%20Java/badge.svg
which does not exist.

The full path of the badge is
    https://github.com/UMM-CSci-3601/3601-lab2_client-server/workflows/Server%20Java/badge.svg
so to reference it from the README, the relative path needs to be
    ../../workflows/Server%20Java/badge.svg

This addresses issue #108 in UMM-CSci-3601/3601-lab2_client-server