### PR TITLE
Add test coverage check to Gradle build

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -60,6 +60,11 @@ application {
 test {
   // Use junit platform for unit tests
   useJUnitPlatform()
+
+  // After running the tests, generate a coverage report
+  finalizedBy jacocoTestReport
+  // After running the tests, check the coverage level
+  finalizedBy jacocoTestCoverageVerification
 }
 
 wrapper {
@@ -67,11 +72,73 @@ wrapper {
 }
 
 jacocoTestReport {
+  // Running the test report task automatically runs test first
+  dependsOn test
+
   reports {
     // This isn't strictly necessary, but the default reports
     // location is buried pretty deep in the build directory,
     // so this makes it easier to find.
     html.destination file("${buildDir}/jacocoHtml")
+  }
+
+  afterEvaluate {
+    // This excludes the `Server` class from the coverage report. We don't
+    // have any good way to test the `Server` class directory (we'd have
+    // to somehow fake incoming HTTP requests), so we are just
+    // leaving it out of the coverage report and the coverage limits.
+    classDirectories.setFrom(files(classDirectories.files.collect {
+      fileTree(dir: it, exclude: 'umm3601/Server.class')
+    }))
+  }
+}
+
+jacocoTestCoverageVerification {
+  // Running the test verification task automatically runs test first
+  dependsOn test
+
+  // These are the rules applied to the test coverage
+  violationRules {
+    rule {
+      // We are looking at the entire bundle overall, i.e.,
+      // 80% of all instructions across all the Java files
+      // (except Server.java) need to be covered.
+      element = 'BUNDLE'
+
+      // 80% of instructions should be covered
+      limit {
+        counter = 'INSTRUCTION'
+        minimum = 0.8
+      }
+
+      // 80% of lines should be covered
+      limit {
+        counter = 'LINE'
+        minimum = 0.8
+      }
+
+      // 80% of branches should be covered
+      limit {
+        counter = 'BRANCH'
+        minimum = 0.8
+      }
+
+      // 80% of methods should be covered
+      limit {
+        counter = 'METHOD'
+        minimum = 0.8
+      }
+    }
+  }
+
+  // This excludes the `Server` class from coverage verification. We don't
+  // have any good way to test the `Server` class directory (we'd have
+  // to somehow fake incoming HTTP requests), so we are just
+  // leaving it out of the coverage report and the coverage limits.
+  afterEvaluate {
+    classDirectories.setFrom(files(classDirectories.files.collect {
+      fileTree(dir: it, exclude: 'umm3601/Server.class')
+    }))
   }
 }
 


### PR DESCRIPTION
This copies over [the changes from the iteration template](https://github.com/UMM-CSci-3601/3601-iteration-template/pull/350) into this project to require at least 80% test coverage in all the Java code except for the Server class (which we can't easily test).

Closes #214 