### PR TITLE
Remove bracket colorization extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -12,10 +12,6 @@
     // https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
     "EditorConfig.EditorConfig",
 
-    // Bracket Pair Colorizer 2
-    // https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2
-    "CoenraadS.bracket-pair-colorizer-2",
-
     // Gradle language support
     // https://marketplace.visualstudio.com/items?itemName=naco-siren.gradle-language
     "naco-siren.gradle-language",


### PR DESCRIPTION
This removes the recommendation that students install the VS Code bracket colorizer extension, since this is now built-in to VS Code.

Closes #215 