### PR TITLE
Remove Guava dependency

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -29,8 +29,6 @@ mainClassName = 'umm3601.Server'
 
 // External dependencies that our application utilizes
 dependencies {
-  // Google core libraries for Java, various useful utilities
-  implementation 'com.google.guava:guava:30.1-jre'
 
   // Javalin, a simple web framework for Java
   implementation 'io.javalin:javalin:4.3.0'


### PR DESCRIPTION
We're not actually using Guava anywhere here, and we're no longer using it later on (like in the iteration template), so we should remove the dependency to, e.g., reduced Dependabot noise.

This should make #199 go away as well.