### PR TITLE
Add checkstyle via gradle

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -8,6 +8,9 @@ plugins {
   // Apply the Jacoco plugin to add suppport for JUnit test coverage
   // reports.
   id 'jacoco'
+
+  // Apply the checkstyle plugin to check for appropriate Java code style.
+  id 'checkstyle'
 }
 
 // Build and run the project with Java 11

--- a/server/config/checkstyle/checkstyle.xml
+++ b/server/config/checkstyle/checkstyle.xml
@@ -1,0 +1,229 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+
+  Checkstyle configuration that checks the sun coding conventions from:
+
+    - the Java Language Specification at
+      https://docs.oracle.com/javase/specs/jls/se11/html/index.html
+
+    - the Sun Code Conventions at https://www.oracle.com/java/technologies/javase/codeconventions-contents.html
+
+    - the Javadoc guidelines at
+      https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html
+
+    - the JDK Api documentation https://docs.oracle.com/en/java/javase/11/
+
+    - some best practices
+
+  Checkstyle is very configurable. Be sure to read the documentation at
+  https://checkstyle.org (or in your downloaded distribution).
+
+  Most Checks are configurable, be sure to consult the documentation.
+
+  To completely disable a check, just comment it out or delete it from the file.
+  To suppress certain violations please review suppression filters.
+
+  Finally, it is worth reading the documentation.
+
+-->
+
+<module name="Checker">
+  <!--
+      If you set the basedir property below, then all reported file
+      names will be relative to the specified directory. See
+      https://checkstyle.org/config.html#Checker
+
+      <property name="basedir" value="${basedir}"/>
+  -->
+  <property name="severity" value="error"/>
+
+  <property name="fileExtensions" value="java, properties, xml"/>
+
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/config_filefilters.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+
+  <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+  <module name="SuppressionFilter">
+    <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
+              default="checkstyle-suppressions.xml" />
+    <property name="optional" value="true"/>
+  </module>
+
+  <!-- Checks that a package-info.java file exists for each package.     -->
+  <!-- See https://checkstyle.org/config_javadoc.html#JavadocPackage -->
+  <!-- <module name="JavadocPackage"/> -->
+
+  <!-- Checks whether files end with a new line.                        -->
+  <!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
+  <module name="NewlineAtEndOfFile"/>
+
+  <!-- Checks that property files contain the same keys.         -->
+  <!-- See https://checkstyle.org/config_misc.html#Translation -->
+  <module name="Translation"/>
+
+  <!-- Checks for Size Violations.                    -->
+  <!-- See https://checkstyle.org/config_sizes.html -->
+  <module name="FileLength"/>
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+    <property name="max" value="120"/>
+  </module>
+
+  <!-- Checks for whitespace                               -->
+  <!-- See https://checkstyle.org/config_whitespace.html -->
+  <module name="FileTabCharacter"/>
+
+  <!-- Miscellaneous other checks.                   -->
+  <!-- See https://checkstyle.org/config_misc.html -->
+  <module name="RegexpSingleline">
+    <property name="format" value="\s+$"/>
+    <property name="minimum" value="0"/>
+    <property name="maximum" value="0"/>
+    <property name="message" value="Line has trailing spaces."/>
+  </module>
+
+  <!-- Checks for Headers                                -->
+  <!-- See https://checkstyle.org/config_header.html   -->
+  <!-- <module name="Header"> -->
+  <!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
+  <!--   <property name="fileExtensions" value="java"/> -->
+  <!-- </module> -->
+
+  <!-- Allows us to suppress warnings with @SupressWarnings annotations. -->
+  <!-- Requires the "SuppressWarningsHolder" module below in the "TreeWalker" section. -->
+  <module name="SuppressWarningsFilter" />
+
+  <module name="TreeWalker">
+    <!-- Allows us to suppress warnings with @SupressWarnings annotations. -->
+    <!-- Also requires the "SuppressWarningsFilter" module above. -->
+    <module name="SuppressWarningsHolder" />
+
+    <!-- Checks for Javadoc comments.                     -->
+    <!-- See https://checkstyle.org/config_javadoc.html -->
+    <!--
+    <module name="InvalidJavadocPosition"/>
+    <module name="JavadocMethod"/>
+    <module name="JavadocType"/>
+    <module name="JavadocVariable"/>
+    <module name="JavadocStyle"/>
+    <module name="MissingJavadocMethod"/>
+    -->
+
+    <!-- Checks for Naming Conventions.                  -->
+    <!-- See https://checkstyle.org/config_naming.html -->
+    <module name="ConstantName"/>
+    <module name="LocalFinalVariableName"/>
+    <module name="LocalVariableName"/>
+    <module name="MemberName"/>
+    <module name="MethodName"/>
+    <!-- <module name="PackageName"/> -->
+    <module name="ParameterName"/>
+    <module name="StaticVariableName"/>
+    <module name="TypeName"/>
+
+    <!-- Checks for imports                              -->
+    <!-- See https://checkstyle.org/config_imports.html -->
+    <module name="AvoidStarImport"/>
+    <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+    <module name="RedundantImport"/>
+    <module name="UnusedImports">
+      <property name="processJavadoc" value="false"/>
+    </module>
+
+    <!-- Checks for Size Violations.                    -->
+    <!-- See https://checkstyle.org/config_sizes.html -->
+    <module name="MethodLength"/>
+    <module name="ParameterNumber"/>
+
+    <!-- Checks for whitespace                               -->
+    <!-- See https://checkstyle.org/config_whitespace.html -->
+    <module name="EmptyForIteratorPad"/>
+    <module name="GenericWhitespace"/>
+    <module name="MethodParamPad"/>
+    <module name="NoWhitespaceAfter"/>
+    <module name="NoWhitespaceBefore"/>
+    <module name="OperatorWrap"/>
+    <module name="ParenPad"/>
+    <module name="TypecastParenPad"/>
+    <module name="WhitespaceAfter"/>
+    <module name="WhitespaceAround"/>
+
+    <!-- Modifier Checks                                    -->
+    <!-- See https://checkstyle.org/config_modifiers.html -->
+    <module name="ModifierOrder"/>
+    <module name="RedundantModifier"/>
+
+    <!-- Checks for blocks. You know, those {}'s         -->
+    <!-- See https://checkstyle.org/config_blocks.html -->
+    <module name="AvoidNestedBlocks"/>
+    <module name="EmptyBlock"/>
+    <module name="LeftCurly"/>
+    <module name="NeedBraces"/>
+    <module name="RightCurly"/>
+
+    <!-- Checks for common coding problems               -->
+    <!-- See https://checkstyle.org/config_coding.html -->
+    <module name="EmptyStatement"/>
+    <module name="EqualsHashCode"/>
+    <module name="HiddenField">
+      <property name="ignoreConstructorParameter" value="true"/>
+      <property name="ignoreSetter" value="true"/>
+      <property name="setterCanReturnItsClass" value="true"/>
+    </module>
+    <module name="IllegalInstantiation"/>
+    <module name="InnerAssignment"/>
+    <module name="MagicNumber"/>
+    <module name="MissingSwitchDefault"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="SimplifyBooleanExpression"/>
+    <module name="SimplifyBooleanReturn"/>
+
+    <!-- Checks for class design                         -->
+    <!-- See https://checkstyle.org/config_design.html -->
+    <!-- This only really makes sense if we're building a reasonably
+         sophisticate OO library, and that kind of design really doesn't
+         come up in this class, because the server library (e.g., Javalin)
+         encapsulates all that design work, leaving us to just act around
+         the "leaves" of the design.
+    <module name="DesignForExtension"/>
+    -->
+    <module name="FinalClass"/>
+    <!-- If everything is static in a class, then it shouldn't have
+         an accessible constructor. This is both subtle and
+         confusing, and not likely to come up much in the class,
+         so we'll just leave it out.
+    <module name="HideUtilityClassConstructor"/>
+    -->
+    <module name="InterfaceIsType"/>
+    <module name="VisibilityModifier"/>
+
+    <!-- Miscellaneous other checks.                   -->
+    <!-- See https://checkstyle.org/config_misc.html -->
+    <module name="ArrayTypeStyle"/>
+    <!-- I (Nic) really likes the *intent* of this rule,
+         but it's really trying to use CheckStyle to fix
+         a mistake in the design of Java. This just confuses
+         students, and requires a ton of extra typing
+         that probably doesn't buy folks much.
+    <module name="FinalParameters"/>
+    -->
+    <module name="TodoComment"/>
+    <module name="UpperEll"/>
+
+    <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+    <module name="SuppressionXpathFilter">
+      <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
+                default="checkstyle-xpath-suppressions.xml" />
+      <property name="optional" value="true"/>
+    </module>
+
+  </module>
+
+</module>

--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -9,6 +9,7 @@ import umm3601.user.UserController;
 
 public class Server {
 
+  private static final int PORT_NUMBER = 4567;
   public static final String CLIENT_DIRECTORY = "../client";
   public static final String USER_DATA_FILE = "/users.json";
   private static UserDatabase userDatabase;
@@ -22,8 +23,8 @@ public class Server {
       // This tells the server where to look for static files,
       // like HTML and JavaScript.
       config.addStaticFiles(CLIENT_DIRECTORY, Location.EXTERNAL);
-      // The next line starts the server listening on port 4567.
-    }).start(4567);
+      // The next line starts the server listening on the specified port.
+    }).start(PORT_NUMBER);
 
     // Simple example route
     server.get("/hello", ctx -> ctx.result("Hello World"));

--- a/server/src/main/java/umm3601/user/User.java
+++ b/server/src/main/java/umm3601/user/User.java
@@ -2,16 +2,16 @@ package umm3601.user;
 
 // There are two examples of suppressing CheckStyle
 // warnings in this class. If you create new classes
-// that mirror data in MongoDB and that will be managed
-// by MongoJack, then you'll probably need to suppress
+// that mirror data in the database and that will be managed
+// by Jackson, then you'll probably need to suppress
 // the same warnings in your classes as well so that
 // CheckStyle doesn't shout at you and cause the build
 // to fail.
 
 // Normally you'd want all fields to be private, but
 // we need the fields in this class to be public since
-// they will be written to by Mongo via the MongoJack
-// library. We need to suppress the Visibility Modifier
+// they will be written to by the Jackson library. We
+// need to suppress the Visibility Modifier
 // (https://checkstyle.sourceforge.io/config_design.html#VisibilityModifier)
 // check in CheckStyle so that we don't get a failed
 // build when Gradle runs CheckStyle.

--- a/server/src/main/java/umm3601/user/User.java
+++ b/server/src/main/java/umm3601/user/User.java
@@ -1,7 +1,26 @@
 package umm3601.user;
 
-public class User {
+// There are two examples of suppressing CheckStyle
+// warnings in this class. If you create new classes
+// that mirror data in MongoDB and that will be managed
+// by MongoJack, then you'll probably need to suppress
+// the same warnings in your classes as well so that
+// CheckStyle doesn't shout at you and cause the build
+// to fail.
 
+// Normally you'd want all fields to be private, but
+// we need the fields in this class to be public since
+// they will be written to by Mongo via the MongoJack
+// library. We need to suppress the Visibility Modifier
+// (https://checkstyle.sourceforge.io/config_design.html#VisibilityModifier)
+// check in CheckStyle so that we don't get a failed
+// build when Gradle runs CheckStyle.
+@SuppressWarnings({"VisibilityModifier"})
+public class User {
+  // By default Java field names shouldn't start with underscores.
+  // Here, though, we *have* to use the name `_id` to match the
+  // name of the field as used by MongoDB.
+  @SuppressWarnings({"MemberName"})
   public String _id;
   public String name;
   public int age;

--- a/server/src/main/java/umm3601/user/User.java
+++ b/server/src/main/java/umm3601/user/User.java
@@ -19,7 +19,7 @@ package umm3601.user;
 public class User {
   // By default Java field names shouldn't start with underscores.
   // Here, though, we *have* to use the name `_id` to match the
-  // name of the field as used by MongoDB.
+  // name of the field in the database.
   @SuppressWarnings({"MemberName"})
   public String _id;
   public String name;

--- a/server/src/main/java/umm3601/user/UserController.java
+++ b/server/src/main/java/umm3601/user/UserController.java
@@ -1,6 +1,7 @@
 package umm3601.user;
 
 import io.javalin.http.Context;
+import io.javalin.http.HttpCode;
 import io.javalin.http.NotFoundResponse;
 
 /**
@@ -33,6 +34,7 @@ public class UserController {
     User user = database.getUser(id);
     if (user != null) {
       ctx.json(user);
+      ctx.status(HttpCode.OK);
     } else {
       throw new NotFoundResponse("No user with id " + id + " was found.");
     }

--- a/server/src/main/java/umm3601/user/UserController.java
+++ b/server/src/main/java/umm3601/user/UserController.java
@@ -33,7 +33,6 @@ public class UserController {
     User user = database.getUser(id);
     if (user != null) {
       ctx.json(user);
-      ctx.status(201);
     } else {
       throw new NotFoundResponse("No user with id " + id + " was found.");
     }

--- a/server/src/test/java/umm3601/user/FilterUsersByAgeFromDB.java
+++ b/server/src/test/java/umm3601/user/FilterUsersByAgeFromDB.java
@@ -14,6 +14,14 @@ import org.junit.jupiter.api.Test;
  * Tests umm3601.user.UserDatabase filterUsersByAge and listUsers with _age_ query
  * parameters
  */
+// The tests here include a ton of "magic numbers" (numeric constants).
+// It wasn't clear to me that giving all of them names would actually
+// help things. The fact that it wasn't obvious what to call some
+// of them says a lot. Maybe what this ultimately means is that
+// these tests can/should be restructured so the constants (there are
+// also a lot of "magic strings" that Checkstyle doesn't actually
+// flag as a problem) make more sense.
+@SuppressWarnings({ "MagicNumber" })
 public class FilterUsersByAgeFromDB {
 
   @Test
@@ -33,11 +41,11 @@ public class FilterUsersByAgeFromDB {
     UserDatabase db = new UserDatabase("/users.json");
     Map<String, List<String>> queryParams = new HashMap<>();
 
-    queryParams.put("age", Arrays.asList(new String[] { "27" }));
+    queryParams.put("age", Arrays.asList(new String[] {"27"}));
     User[] age27Users = db.listUsers(queryParams);
     assertEquals(3, age27Users.length, "Incorrect number of users with age 27");
 
-    queryParams.put("age", Arrays.asList(new String[] { "33" }));
+    queryParams.put("age", Arrays.asList(new String[] {"33"}));
     User[] age33Users = db.listUsers(queryParams);
     assertEquals(1, age33Users.length, "Incorrect number of users with age 33");
   }

--- a/server/src/test/java/umm3601/user/FilterUsersByCombinedFiltersFromDB.java
+++ b/server/src/test/java/umm3601/user/FilterUsersByCombinedFiltersFromDB.java
@@ -21,18 +21,18 @@ public class FilterUsersByCombinedFiltersFromDB {
     UserDatabase db = new UserDatabase("/users.json");
     Map<String, List<String>> queryParams = new HashMap<>();
 
-    queryParams.put("age", Arrays.asList(new String[] { "25" }));
+    queryParams.put("age", Arrays.asList(new String[] {"25"}));
     User[] age25Users = db.listUsers(queryParams);
     assertEquals(2, age25Users.length, "Incorrect number of users with age 25");
 
     queryParams.clear();
-    queryParams.put("company", Arrays.asList(new String[] { "OHMNET" }));
+    queryParams.put("company", Arrays.asList(new String[] {"OHMNET"}));
     User[] ohmnetUsers = db.listUsers(queryParams);
     assertEquals(2, ohmnetUsers.length, "Incorrect number of users with company OHMNET");
 
     queryParams.clear();
-    queryParams.put("age", Arrays.asList(new String[] { "25" }));
-    queryParams.put("company", Arrays.asList(new String[] { "OHMNET" }));
+    queryParams.put("age", Arrays.asList(new String[] {"25"}));
+    queryParams.put("company", Arrays.asList(new String[] {"OHMNET"}));
     User[] ohmnetAge25Users = db.listUsers(queryParams);
     assertEquals(1, ohmnetAge25Users.length, "Incorrect number of users with company OHMNET and age 25");
   }

--- a/server/src/test/java/umm3601/user/FullUserListFromDB.java
+++ b/server/src/test/java/umm3601/user/FullUserListFromDB.java
@@ -10,6 +10,14 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests umm3601.user.UserDatabase listUser functionality
  */
+// The tests here include a ton of "magic numbers" (numeric constants).
+// It wasn't clear to me that giving all of them names would actually
+// help things. The fact that it wasn't obvious what to call some
+// of them says a lot. Maybe what this ultimately means is that
+// these tests can/should be restructured so the constants (there are
+// also a lot of "magic strings" that Checkstyle doesn't actually
+// flag as a problem) make more sense.
+@SuppressWarnings({ "MagicNumber" })
 public class FullUserListFromDB {
 
   @Test

--- a/server/src/test/java/umm3601/user/UserControllerSpec.java
+++ b/server/src/test/java/umm3601/user/UserControllerSpec.java
@@ -96,7 +96,7 @@ public class UserControllerSpec {
    * we get a reasonable error code back.
    */
   @Test
-  public void respondAppropriatelyToIllegalAge() {
+  public void respondsAppropriatelyToIllegalAge() {
     // We'll set the requested "age" to be a string ("abc")
     // that can't be parsed to a number.
     Map<String, List<String>> queryParams = new HashMap<>();

--- a/server/src/test/java/umm3601/user/UserControllerSpec.java
+++ b/server/src/test/java/umm3601/user/UserControllerSpec.java
@@ -27,6 +27,14 @@ import umm3601.Server;
  *
  * @throws IOException
  */
+// The tests here include a ton of "magic numbers" (numeric constants).
+// It wasn't clear to me that giving all of them names would actually
+// help things. The fact that it wasn't obvious what to call some
+// of them says a lot. Maybe what this ultimately means is that
+// these tests can/should be restructured so the constants (there are
+// also a lot of "magic strings" that Checkstyle doesn't actually
+// flag as a problem) make more sense.
+@SuppressWarnings({ "MagicNumber" })
 public class UserControllerSpec {
 
   private Context ctx = mock(Context.class);
@@ -56,7 +64,7 @@ public class UserControllerSpec {
   @Test
   public void GET_to_request_age_25_users() throws IOException {
     Map<String, List<String>> queryParams = new HashMap<>();
-    queryParams.put("age", Arrays.asList(new String[] { "25" }));
+    queryParams.put("age", Arrays.asList(new String[] {"25"}));
     when(ctx.queryParamMap()).thenReturn(queryParams);
 
     userController.getUsers(ctx);
@@ -79,7 +87,7 @@ public class UserControllerSpec {
     // We'll set the requested "age" to be a string ("abc")
     // that can't be parsed to a number.
     Map<String, List<String>> queryParams = new HashMap<>();
-    queryParams.put("age", Arrays.asList(new String[] { "abc" }));
+    queryParams.put("age", Arrays.asList(new String[] {"abc"}));
 
     when(ctx.queryParamMap()).thenReturn(queryParams);
     // This should now throw a `BadRequestResponse` exception because
@@ -93,7 +101,7 @@ public class UserControllerSpec {
   public void GET_to_request_company_OHMNET_users() throws IOException {
 
     Map<String, List<String>> queryParams = new HashMap<>();
-    queryParams.put("company", Arrays.asList(new String[] { "OHMNET" }));
+    queryParams.put("company", Arrays.asList(new String[] {"OHMNET"}));
 
     when(ctx.queryParamMap()).thenReturn(queryParams);
     userController.getUsers(ctx);
@@ -110,9 +118,9 @@ public class UserControllerSpec {
   public void GET_to_request_company_OHMNET_age_25_users() throws IOException {
 
     Map<String, List<String>> queryParams = new HashMap<>();
-    queryParams.put("company", Arrays.asList(new String[] { "OHMNET" }));
+    queryParams.put("company", Arrays.asList(new String[] {"OHMNET"}));
 
-    queryParams.put("age", Arrays.asList(new String[] { "25" }));
+    queryParams.put("age", Arrays.asList(new String[] {"25"}));
 
     when(ctx.queryParamMap()).thenReturn(queryParams);
     userController.getUsers(ctx);

--- a/server/src/test/java/umm3601/user/UserControllerSpec.java
+++ b/server/src/test/java/umm3601/user/UserControllerSpec.java
@@ -159,7 +159,7 @@ public class UserControllerSpec {
   }
 
   @Test
-  public void respondAppropriatelyToRequestForNonexistentId() throws IOException {
+  public void respondsAppropriatelyToRequestForNonexistentId() throws IOException {
     when(ctx.pathParam("id")).thenReturn(null);
     Assertions.assertThrows(NotFoundResponse.class, () -> {
       userController.getUser(ctx);

--- a/server/src/test/java/umm3601/user/UserControllerSpec.java
+++ b/server/src/test/java/umm3601/user/UserControllerSpec.java
@@ -51,9 +51,16 @@ public class UserControllerSpec {
     userController = new UserController(db);
   }
 
+  /**
+   * Confirms that we can get all the users.
+   *
+   * @throws IOException
+   */
   @Test
-  public void GET_to_request_all_users() throws IOException {
-    // Call the method on the mock controller
+  public void canGetAllUsers() throws IOException {
+    // Call the method on the mock context, which doesn't
+    // include any filters, so we should get all the users
+    // back.
     userController.getUsers(ctx);
 
     // Confirm that `json` was called with all the users.
@@ -63,11 +70,16 @@ public class UserControllerSpec {
   }
 
   @Test
-  public void GET_to_request_age_25_users() throws IOException {
+  public void canGetUsersWithAge25() throws IOException {
+    // Add a query param map to the context that maps "age"
+    // to "25".
     Map<String, List<String>> queryParams = new HashMap<>();
     queryParams.put("age", Arrays.asList(new String[] {"25"}));
     when(ctx.queryParamMap()).thenReturn(queryParams);
 
+    // Call the method on the mock controller with the added
+    // query param map to limit the result to just users with
+    // age 25.
     userController.getUsers(ctx);
 
     // Confirm that all the users passed to `json` have age 25.
@@ -84,13 +96,13 @@ public class UserControllerSpec {
    * we get a reasonable error code back.
    */
   @Test
-  public void GET_to_request_users_with_illegal_age() {
+  public void respondAppropriatelyToIllegalAge() {
     // We'll set the requested "age" to be a string ("abc")
     // that can't be parsed to a number.
     Map<String, List<String>> queryParams = new HashMap<>();
     queryParams.put("age", Arrays.asList(new String[] {"abc"}));
-
     when(ctx.queryParamMap()).thenReturn(queryParams);
+
     // This should now throw a `BadRequestResponse` exception because
     // our request has an age that can't be parsed to a number.
     Assertions.assertThrows(BadRequestResponse.class, () -> {
@@ -99,12 +111,11 @@ public class UserControllerSpec {
   }
 
   @Test
-  public void GET_to_request_company_OHMNET_users() throws IOException {
-
+  public void canGetUsersWithCompany() throws IOException {
     Map<String, List<String>> queryParams = new HashMap<>();
     queryParams.put("company", Arrays.asList(new String[] {"OHMNET"}));
-
     when(ctx.queryParamMap()).thenReturn(queryParams);
+
     userController.getUsers(ctx);
 
     // Confirm that all the users passed to `json` work for OHMNET.
@@ -116,14 +127,12 @@ public class UserControllerSpec {
   }
 
   @Test
-  public void GET_to_request_company_OHMNET_age_25_users() throws IOException {
-
+  public void canGetUsersWithGivenAgeAndCompany() throws IOException {
     Map<String, List<String>> queryParams = new HashMap<>();
     queryParams.put("company", Arrays.asList(new String[] {"OHMNET"}));
-
     queryParams.put("age", Arrays.asList(new String[] {"25"}));
-
     when(ctx.queryParamMap()).thenReturn(queryParams);
+
     userController.getUsers(ctx);
 
     // Confirm that all the users passed to `json` work for OHMNET
@@ -137,18 +146,20 @@ public class UserControllerSpec {
   }
 
   @Test
-  public void GET_to_request_user_with_existent_id() throws IOException {
+  public void canGetUserWithSpecifiedId() throws IOException {
     String id = "588935f5c668650dc77df581";
     User user = db.getUser(id);
 
     when(ctx.pathParam("id")).thenReturn(id);
+
     userController.getUser(ctx);
+
     verify(ctx).json(user);
     verify(ctx).status(HttpCode.OK);
   }
 
   @Test
-  public void GET_to_request_user_with_nonexistent_id() throws IOException {
+  public void respondAppropriatelyToRequestForNonexistentId() throws IOException {
     when(ctx.pathParam("id")).thenReturn(null);
     Assertions.assertThrows(NotFoundResponse.class, () -> {
       userController.getUser(ctx);

--- a/server/src/test/java/umm3601/user/UserControllerSpec.java
+++ b/server/src/test/java/umm3601/user/UserControllerSpec.java
@@ -18,6 +18,7 @@ import org.mockito.ArgumentCaptor;
 
 import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
+import io.javalin.http.HttpCode;
 import io.javalin.http.NotFoundResponse;
 
 import umm3601.Server;
@@ -143,7 +144,7 @@ public class UserControllerSpec {
     when(ctx.pathParam("id")).thenReturn(id);
     userController.getUser(ctx);
     verify(ctx).json(user);
-    verify(ctx).status(201);
+    verify(ctx).status(HttpCode.OK);
   }
 
   @Test


### PR DESCRIPTION
This adds Checkstyle support via Gradle, and gets our code so that it passes.

Getting things to pass included changing all the method names in `UserControllerSpec`, which will close #172.

This also inadvertently fixed #171 in the removal of a magic number.

Closes #171 
Closes #172 
Closes #225 