### PR TITLE
Change VS Code to launch Java in "Standard" mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-    "java.configuration.updateBuildConfiguration": "automatic"
+    "java.configuration.updateBuildConfiguration": "automatic",
+    "java.server.launchMode": "Standard",
+    "cSpell.words": [
+        "Javalin"
+    ]
 }


### PR DESCRIPTION
This should improve VS Code's analysis when launched on this project.

Closes #166