### PR TITLE
Replace GSON with Jackson

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -35,10 +35,9 @@ dependencies {
 
   // Jackson, a JSON library for Java
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
+
   // Simple Logging Facade for Java
   implementation 'org.slf4j:slf4j-simple:1.7.35'
-
-  implementation 'com.google.code.gson:gson:2.8.9'
 
   // JUnit Jupiter API for testing.
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'

--- a/server/src/main/java/umm3601/user/UserDatabase.java
+++ b/server/src/main/java/umm3601/user/UserDatabase.java
@@ -6,8 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import com.google.gson.Gson;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.javalin.http.BadRequestResponse;
 
 /**
@@ -23,9 +22,9 @@ public class UserDatabase {
   private User[] allUsers;
 
   public UserDatabase(String userDataFile) throws IOException {
-    Gson gson = new Gson();
     InputStreamReader reader = new InputStreamReader(getClass().getResourceAsStream(userDataFile));
-    allUsers = gson.fromJson(reader, User[].class);
+    ObjectMapper objectMapper = new ObjectMapper();
+    allUsers = objectMapper.readValue(reader, User[].class);
   }
 
   public int size() {


### PR DESCRIPTION
Since Javalin depends on Jackson for JSON (de)serializing, there's really no point in continuing to use GSON for that. This replaces the one use of GSON with Jackson, and eliminates the dependency on the GSON library, which should reduce the Dependabot noise a wee bit.

Closes #95