### PR TITLE
Set up the Javalin RouteOverviewPlugin

### DIFF
--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -3,6 +3,7 @@ package umm3601;
 import java.io.IOException;
 
 import io.javalin.Javalin;
+import io.javalin.core.util.RouteOverviewPlugin;
 import io.javalin.http.staticfiles.Location;
 import umm3601.user.UserDatabase;
 import umm3601.user.UserController;
@@ -22,6 +23,10 @@ public class Server {
       // This tells the server where to look for static files,
       // like HTML and JavaScript.
       config.addStaticFiles(CLIENT_DIRECTORY, Location.EXTERNAL);
+      // This adds a Javalin plugin that will list all of the
+      // routes/endpoints that we add below on a page reachable
+      // via the "/api" path.
+      config.registerPlugin(new RouteOverviewPlugin("/api"));
       // The next line starts the server listening on port 4567.
     }).start(4567);
 

--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -25,8 +25,8 @@ public class Server {
       config.addStaticFiles(CLIENT_DIRECTORY, Location.EXTERNAL);
       // This adds a Javalin plugin that will list all of the
       // routes/endpoints that we add below on a page reachable
-      // via the "/api" path.
-      config.registerPlugin(new RouteOverviewPlugin("/api"));
+      // via the "/route-overview" path.
+      config.registerPlugin(new RouteOverviewPlugin("/route-overview"));
       // The next line starts the server listening on port 4567.
     }).start(4567);
 


### PR DESCRIPTION
This adds an "/api" route that is populated by Javalin's RouteOverviewPlugin. This doesn't give us a *ton* of information, but it does list all the supported routes.

It was really easy to do, so I suspect we should go ahead and merge this in?

My sense is that going with [the OpenAPI plugin](https://javalin.io/plugins/openapi) would be more informative, but that's not happening this week. I'm also not sure if the added info would be worth the extra complication that would come with it.

Closes #169 