### PR TITLE
Simplify/update some things in the server and client

### DIFF
--- a/LABTASKS.md
+++ b/LABTASKS.md
@@ -284,7 +284,7 @@ Explain what happens when a user accesses each of the
 following URLs:
 
 * :question: The page `users`
-  * <http://localhost:4567/users>
+  * <http://localhost:4567/users.html>
 * :question: The page `api/users`
   * <http://localhost:4567/api/users>
 * :question: The page `api/users?age=25`

--- a/LABTASKS.md
+++ b/LABTASKS.md
@@ -284,7 +284,7 @@ Explain what happens when a user accesses each of the
 following URLs:
 
 * :question: The page `users`
-  * <http://localhost:4567/users.html>
+  * <http://localhost:4567/users>
 * :question: The page `api/users`
   * <http://localhost:4567/api/users>
 * :question: The page `api/users?age=25`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - [Setup](#setup)
   - [Cloning the project in GitKraken](#cloning-the-project-in-gitkraken)
   - [Open the project in VS Code](#open-the-project-in-vs-code)
-  - [JSONView browser extension](#jsonview-browser-extension)
+  - [JSON viewer browser extension](#json-viewer-browser-extension)
 - [Running Your project](#running-your-project)
 - [Testing Your Project](#testing-your-project)
 - [Checking your code coverage](#checking-your-code-coverage)
@@ -101,9 +101,9 @@ Don't worry if you don't get the dialog, it is probably because you already have
 
 Like in previous labs, click "Install All" to automatically install them.
 
-### JSONView browser extension
+### JSON viewer browser extension
 
-If you use Chrome, you may find it helpful to install the [JSONView][jsonview-chrome] extension.
+If you use Chrome, you may find it helpful to install the [JSONVue][jsonview-chrome] extension.
 This will make JSON in the browser look pretty and actually be readable when you visit the different API endpoints.
 
 If you use Firefox, this functionality is built-in, so there is no need to install an extension.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Like in previous labs, click "Install All" to automatically install them.
 
 ### JSON viewer browser extension
 
-If you use Chrome, you may find it helpful to install the [JSONVue][jsonview-chrome] extension.
+If you use Chrome, you may find it helpful to install the [JSONVue][jsonvue-chrome] extension.
 This will make JSON in the browser look pretty and actually be readable when you visit the different API endpoints.
 
 If you use Firefox, this functionality is built-in, so there is no need to install an extension.
@@ -222,7 +222,7 @@ most of the actual work of the lab is described.
 
 [javalin-io]: https://javalin.io
 [gradle]: https://gradle.org/
-[jsonview-chrome]: https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc?hl=en
+[jsonvue-chrome]: https://chrome.google.com/webstore/detail/jsonvue/chklaanhfefbnpoihckbnefhakgolnmc?hl=en
 [labtasks]: LABTASKS.md
 [local]: http://localhost:4567/
 [rest-best-practices]: https://medium.com/@mwaysolutions/10-best-practices-for-better-restful-api-cbe81b06f291

--- a/client/index.html
+++ b/client/index.html
@@ -8,8 +8,8 @@
 </head>
 <body>
   Home |
-  <a href="/users.html">Users</a> |
-  <a href="/todos.html">Todos</a>
+  <a href="/users">Users</a> |
+  <a href="/todos">Todos</a>
   <hr>
   <h2>Welcome to Lab 2</h2>
   <p>This is a basic demo site to test your API with.</p>

--- a/client/index.html
+++ b/client/index.html
@@ -13,5 +13,6 @@
   <hr>
   <h2>Welcome to Lab 2</h2>
   <p>This is a basic demo site to test your API with.</p>
+  <p>The route overview is <a href="/api" target="_blank">here</a>.</p>
 </body>
 </html>

--- a/client/index.html
+++ b/client/index.html
@@ -8,8 +8,8 @@
 </head>
 <body>
   Home |
-  <a href="/users">Users</a> |
-  <a href="/todos">Todos</a>
+  <a href="/users.html">Users</a> |
+  <a href="/todos.html">Todos</a>
   <hr>
   <h2>Welcome to Lab 2</h2>
   <p>This is a basic demo site to test your API with.</p>

--- a/client/todos.html
+++ b/client/todos.html
@@ -11,7 +11,7 @@
 </head>
 <body>
   <a href="/">Home</a> |
-  <a href="/users.html">Users</a> |
+  <a href="/users">Users</a> |
   Todos
   <hr>
 

--- a/client/todos.html
+++ b/client/todos.html
@@ -5,13 +5,13 @@
   <title>Todos</title>
   <!-- sakura is a minimal classless css framework / theme that provides some basic styling for us  -->
   <link rel="stylesheet" type="text/css" href="https://unpkg.com/sakura.css/css/sakura.css">
-  <link rel="stylesheet" type="text/css" href="css/json-syntax.css">
-  <script type="text/javascript" src="javascript/util.js"></script>
-  <script type="text/javascript" src="javascript/todos.js"> </script>
+  <link rel="stylesheet" type="text/css" href="/css/json-syntax.css">
+  <script type="text/javascript" src="/javascript/util.js"></script>
+  <script type="text/javascript" src="/javascript/todos.js"> </script>
 </head>
 <body>
   <a href="/">Home</a> |
-  <a href="/users">Users</a> |
+  <a href="/users.html">Users</a> |
   Todos
   <hr>
 

--- a/client/users.html
+++ b/client/users.html
@@ -12,7 +12,7 @@
 <body>
   <a href="/">Home</a> |
   Users |
-  <a href="/todos.html">Todos</a>
+  <a href="/todos">Todos</a>
 
   <hr/>
 

--- a/client/users.html
+++ b/client/users.html
@@ -5,14 +5,14 @@
   <title>Users</title>
   <!-- sakura is a minimal classless css framework / theme that provides some basic styling for us  -->
   <link rel="stylesheet" type="text/css" href="https://unpkg.com/sakura.css/css/sakura.css">
-  <link rel="stylesheet" type="text/css" href="css/json-syntax.css">
-  <script type="text/javascript" src="javascript/util.js"></script>
-  <script type="text/javascript" src="javascript/users.js"></script>
+  <link rel="stylesheet" type="text/css" href="/css/json-syntax.css">
+  <script type="text/javascript" src="/javascript/util.js"></script>
+  <script type="text/javascript" src="/javascript/users.js"></script>
 </head>
 <body>
   <a href="/">Home</a> |
   Users |
-  <a href="/todos">Todos</a>
+  <a href="/todos.html">Todos</a>
 
   <hr/>
 

--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -34,6 +34,10 @@ public class Server {
     // Simple example route
     server.get("/hello", ctx -> ctx.result("Hello World"));
 
+    // Redirects to create simpler URLs
+    server.get("/users", ctx -> ctx.redirect("/users.html"));
+    server.get("/todos", ctx -> ctx.redirect("/todos.html"));
+
     // API endpoints
 
     // Get specific user

--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -34,10 +34,6 @@ public class Server {
     // Simple example route
     server.get("/hello", ctx -> ctx.result("Hello World"));
 
-    // Redirects to create simpler URLs
-    server.get("/users", ctx -> ctx.redirect("/users.html"));
-    server.get("/todos", ctx -> ctx.redirect("/todos.html"));
-
     // API endpoints
 
     // Get specific user

--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -41,10 +41,10 @@ public class Server {
     // API endpoints
 
     // Get specific user
-    server.get("/api/users/{id}", ctx -> userController.getUser(ctx));
+    server.get("/api/users/{id}", userController::getUser);
 
     // List users, filtered using query parameters
-    server.get("/api/users", ctx -> userController.getUsers(ctx));
+    server.get("/api/users", userController::getUsers);
   }
 
   /***

--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -26,8 +26,8 @@ public class Server {
       config.addStaticFiles(CLIENT_DIRECTORY, Location.EXTERNAL);
       // This adds a Javalin plugin that will list all of the
       // routes/endpoints that we add below on a page reachable
-      // via the "/route-overview" path.
-      config.registerPlugin(new RouteOverviewPlugin("/route-overview"));
+      // via the "/api" path.
+      config.registerPlugin(new RouteOverviewPlugin("/api"));
       // The next line starts the server listening on port 4567.
     }).start(PORT_NUMBER);
 


### PR DESCRIPTION
This makes a few small changes to either simplify or update a few things.

- It uses the newer lambda syntax for the users api routes like we do in future labs. eg: `userController::getUsers` rather than `ctx -> userController.getUsers(ctx)`
- Removes the `/users` -> `/users.html` and `/todos` -> `/todos.html` redirects and directly references the `.html` paths instead. The browser was just being redirected from `/users` to `/users.html` anyway rather than `/users` being rewritten to the content of the html as I probably originally intended.
- Changes the route overview back to `/api`. This keeps it consistent with the future labs and gives something useful at `/api` rather than just an error. I also added a link to this route overview on the index page of the client.
- Use the correct name for the [JSONVue](https://chrome.google.com/webstore/detail/jsonvue/chklaanhfefbnpoihckbnefhakgolnmc?hl=en) Chrome extension. It looks like the name was changed from JSONView to JSONVue at some point.