### PR TITLE
Add `pull_request` as a trigger for workflows

### DIFF
--- a/.github/workflows/server-gradle.yml
+++ b/.github/workflows/server-gradle.yml
@@ -1,6 +1,6 @@
 name: Server Java
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   gradle-build:


### PR DESCRIPTION
The GitHub actions checks are hanging on a PR from @JustusFluegel from a fork of this repository. I think this is because we don't have `on: pull_request` set in the workflow file.